### PR TITLE
Summarize gsutil log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM vanallenlab/miniconda:3.6
+FROM vanallenlab/miniconda:3.9
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl gnupg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
 
 COPY requirements.txt /
@@ -17,9 +17,13 @@ COPY terra-helper/copy_multiple_buckets.sh /terra-helper/
 COPY terra-helper/create_workspace.py /terra-helper/
 COPY terra-helper/estimate_archive_and_retrieval_cost.py /terra-helper/
 COPY terra-helper/get_file_sizes.sh /terra-helper/
-COPY terra-helper/index_workspace.py /terra-helper/
+COPY terra-helper/get_workspace_attributes.py /terra-helper/
+COPY terra-helper/get_workspace_bucket_contents.py /terra-helper/
+COPY terra-helper/identify_files_manually_clean_workspace.py /terra-helper/
 COPY terra-helper/list_source_files.py /terra-helper/
 COPY terra-helper/list_workspaces.py /terra-helper/
+COPY terra-helper/operations.py /terra-helper/
+COPY terra-helper/reformat.py /terra-helper/
 COPY terra-helper/remove_files.sh /terra-helper/
 COPY terra-helper/restore_bucket.sh /terra-helper/
 COPY terra-helper/restore_files.sh /terra-helper/
@@ -27,6 +31,6 @@ COPY terra-helper/summarize_copy_log.py /terra-helper/
 COPY terra-helper/endpoints/ /terra-helper/endpoints/
 COPY terra-helper/README.md /terra-helper/
 
-COPY docs/ /docs/
+COPY docs/* /docs/
 COPY README.md /
 COPY Dockerfile /

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,27 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 COPY requirements.txt /
 RUN pip install -r requirements.txt
 
-COPY copy_bucket.sh /
-COPY copy_bucket-mirror.sh /
-COPY copy_multiple_buckets.sh /
-COPY create_workspace.py /
-COPY estimate_archive_and_retrieval_cost.py /
-COPY get_file_sizes.sh /
-COPY index_workspace.py /
-COPY list_source_files.py /
-COPY list_workspaces.py /
-COPY remove_files.sh /
-COPY restore_bucket.sh /
-COPY restore_files.sh /
+RUN mkdir /terra-helper/
+RUN mkdir /terra-helper/endpoints/
 
-COPY use-cases/ /use-cases/
+COPY LICENSE /
+
+COPY terra-helper/copy_bucket.sh /terra-helper/
+COPY terra-helper/copy_bucket-mirror.sh /terra-helper/
+COPY terra-helper/copy_multiple_buckets.sh /terra-helper/
+COPY terra-helper/create_workspace.py /terra-helper/
+COPY terra-helper/estimate_archive_and_retrieval_cost.py /terra-helper/
+COPY terra-helper/get_file_sizes.sh /terra-helper/
+COPY terra-helper/index_workspace.py /terra-helper/
+COPY terra-helper/list_source_files.py /terra-helper/
+COPY terra-helper/list_workspaces.py /terra-helper/
+COPY terra-helper/remove_files.sh /terra-helper/
+COPY terra-helper/restore_bucket.sh /terra-helper/
+COPY terra-helper/restore_files.sh /terra-helper/
+COPY terra-helper/summarize_copy_log.py /terra-helper/
+COPY terra-helper/endpoints/ /terra-helper/endpoints/
+COPY terra-helper/README.md /terra-helper/
+
+COPY docs/ /docs/
 COPY README.md /
-COPY documentation.md /
 COPY Dockerfile /

--- a/terra-helper/README.md
+++ b/terra-helper/README.md
@@ -19,6 +19,7 @@ Run scripts from this directory. The table of contents contains a hyperlink to a
 - [remove_files.sh](#remove_filessh)
 - [restore_bucket.sh](#restore_bucketsh)
 - [restore_files.sh](#restore_filessh)
+- [summarize_gsutil_copy_log.py]()
 
 ## copy_bucket.sh
 `copy_bucket.sh` will copy the contents of one bucket to another. Contents of the source bucket will be placed in folder named after the source bucket within the destination bucket, with folder structure mirrored. Specifically, the following will result in passing `fc-01e89ec0-c3b9-4a2f-9a70-21460d4427af` as a source bucket and `terra-workspace-archive-us-central1` as the destination bucket:
@@ -510,6 +511,44 @@ Outputs produced:
 Example:
 ```bash
 bash restore_files.sh fc-01e89ec0-c3b9-4a2f-9a70-21460d4427af-to-terra-workspace-archive-us-central1.gsutil_copy_log.csv fc-01e89ec0-c3b9-4a2f-9a70-21460d4427af-restored
+```
+
+[Back to table of contents](#table-of-contents)
+
+## summarize_gsutil_copy_log.py
+`summarize_gsutil_copy_log.py` is used to produce a summary of a gsutil copy log from `gsutil cp`. This script assumes that the gsutil copy log is still a comma delimited, `.csv`, file format. In particular the script will summarize,
+- How many files were attempted for copying
+- How many files were successfully copied
+- How many bytes were attempted for copying
+- How many bytes were successfully copied
+- If the file count attempted match the file count successful
+- If the bytes attempted matched those successful
+
+### Usage
+Required arguments:
+```bash
+    --input, -i         <string>    Path to gsutil copy log
+```
+
+Optional arguments:
+```bash
+    --output, -o        <boolean>    Argument passed to instruct the script to produce output files
+```
+
+Outputs produced:
+
+| File name                 | Description                                                                                            |
+|---------------------------|--------------------------------------------------------------------------------------------------------|
+| `n_files_attempted.txt`   | A file that contains a single integer of the number of files attempted to be copied.                   |
+| `n_files_success.txt`     | A file that contains a single integer of the number of files successfully copied.                      |
+| `bytes_attempted.txt`     | A file that contains a single integer of the number of bytes attempted to be copied.                   |
+| `bytes_success.txt`       | A file that contains a single integer of the number of bytes successfully copied.                      |
+| `all_files_succeeded.txt` | A file that contains a single boolean stating that file count attempted equals those succeeded or not. |
+| `all_bytes_succeeded.txt` | A file that contains a single boolean stating that the bytes attempted equals those succeeded or not.  |
+
+Example:
+```bash
+python summarize_gsutil_copy.py -i fc-01e89ec0-c3b9-4a2f-9a70-21460d4427af-to-terra-workspace-archive-us-central1.gsutil_copy_log.csv -o
 ```
 
 [Back to table of contents](#table-of-contents)

--- a/terra-helper/summarize_copy_log.py
+++ b/terra-helper/summarize_copy_log.py
@@ -1,0 +1,47 @@
+import argparse
+import pandas as pd
+
+
+def read(handle):
+    return pd.read_csv(handle, low_memory=False)
+
+
+def write(value, filename):
+    pd.Series(value).to_csv(filename, sep='\t', index=False, header=False)
+
+
+def main(df, write_outputs=False):
+    succeeded = df[df['Result'].eq('OK')]
+
+    bytes_attempted = df['Source Size'].sum()
+    bytes_success = succeeded['Bytes Transferred'].sum()
+
+    n_files_attempted = df.shape[0]
+    n_files_success = succeeded.shape[0]
+    print(f'Attempted: {n_files_attempted} files, {bytes_attempted} bytes')
+    print(f'Successfully transferred: {n_files_success} files, {bytes_success} bytes')
+
+    if write_outputs:
+        write(bytes_attempted, 'bytes_attempted.txt')
+        write(bytes_success, 'bytes_success.txt')
+        write(n_files_attempted, 'n_files_attempted.txt')
+        write(n_files_success, 'n_files_success.txt')
+
+    all_files_succeeded = n_files_attempted == n_files_success
+    all_bytes_succeeded = bytes_attempted == bytes_success
+    print(f'All files attempted successfully transferred: {all_files_succeeded}')
+    print(f'All bytes attempted successfully transferred: {all_bytes_succeeded}')
+
+    if write_outputs:
+        write(all_files_succeeded, 'all_files_succeeded.txt')
+        write(all_bytes_succeeded, 'all_bytes_succeeded.txt')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog='summarize_copy_log.py', description='Summarize gsutil copy')
+    parser.add_argument('--input', '-i', required=True, help='gsutil copy log')
+    parser.add_argument('--output', '-o', action="store_true", help='produce output files')
+    args = parser.parse_args()
+
+    dataframe = read(args.input)
+    main(dataframe, args.output)


### PR DESCRIPTION
This pull request is for the addition of `summarize_gsutil_copy_log.py`, a script to summarize the number of files and bytes attempted and successfully copied using `gsutil cp`. Results are printed into terminal and outputs are produced optionally. 

Additions:
- The script `summarize_gsutil_copy_log.py` and accompanying documentation
- This version of terra-helper has been released on DockerHub as vanallenlab/terra-helper:1.1.0

Revisions:
- The DockerFile was revised to pull from miniconda:3.9
- The DockerFile was revised to add a dependency required for ubuntu 