### PR TITLE
Revise copy bucket log naming

### DIFF
--- a/terra-helper/copy_bucket-mirror.sh
+++ b/terra-helper/copy_bucket-mirror.sh
@@ -13,11 +13,5 @@ log_prefix="$source-to-$destination"
 log_prefix_slash_removed="${log_prefix/\//.}"
 log="$log_prefix_slash_removed".gsutil_copy_log.csv
 
-echo $source
-echo $destination
-echo $log_prefix
-echo $log_prefix_slash_removed
-echo $log
-
 gsutil -m cp -L "$log" -r gs://"$source"/* gs://"$destination"
 

--- a/terra-helper/copy_bucket-mirror.sh
+++ b/terra-helper/copy_bucket-mirror.sh
@@ -10,7 +10,14 @@ prefix=gs://
 source=${SOURCE//$prefix/}
 destination=${DESTINATION//$prefix/}
 log_prefix="$source-to-$destination"
-log="$log_prefix".gsutil_copy_log.csv
+log_prefix_slash_removed="${log_prefix/\//.}"
+log="$log_prefix_slash_removed".gsutil_copy_log.csv
+
+echo $source
+echo $destination
+echo $log_prefix
+echo $log_prefix_slash_removed
+echo $log
 
 gsutil -m cp -L "$log" -r gs://"$source"/* gs://"$destination"
 

--- a/terra-helper/copy_bucket.sh
+++ b/terra-helper/copy_bucket.sh
@@ -11,6 +11,13 @@ prefix=gs://
 source=${SOURCE//$prefix/}
 destination=${DESTINATION//$prefix/}
 log_prefix="$source-to-$destination"
-log="$log_prefix".gsutil_copy_log.csv
+log_prefix_slash_removed="${log_prefix/\//.}"
+log="$log_prefix_slash_removed".gsutil_copy_log.csv
+
+echo $source
+echo $destination
+echo $log_prefix
+echo $log_prefix_slash_removed
+echo $log
 
 gsutil -m cp -L "$log" -r gs://"$source" gs://"$destination"

--- a/terra-helper/copy_bucket.sh
+++ b/terra-helper/copy_bucket.sh
@@ -14,10 +14,4 @@ log_prefix="$source-to-$destination"
 log_prefix_slash_removed="${log_prefix/\//.}"
 log="$log_prefix_slash_removed".gsutil_copy_log.csv
 
-echo $source
-echo $destination
-echo $log_prefix
-echo $log_prefix_slash_removed
-echo $log
-
 gsutil -m cp -L "$log" -r gs://"$source" gs://"$destination"


### PR DESCRIPTION
This pull request revises `copy_bucket.sh` and `copy_bucket-mirror.sh` to change how the gsutil copy log is named. In particular, forward slashes in either the destination or source bucket will be replaced with a period when creating the string for log naming. This is needed when either the source or destination is folder within a bucket. 

Revisions, 
- `copy_bucket.sh` and `copy_bucket-mirror.sh` both added a variable `log_prefix_slash_removed`, which replaces forward slashes with periods from the string `log_prefix`. This string is then used to name the copy log.